### PR TITLE
Enable Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: python
+python:
+  - "2.7"
+# command to install dependencies
+# install: "pip install -r requirements.txt"
+# command to run tests
+script: py.test tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,1 @@
+Until we have actual tests, this is a placeholder so Git keeps the directory.


### PR DESCRIPTION
The installation command is commented out, but is in fact what should be the default _if_ a `requirements.txt` file is present. At first we won't have a `requirements.txt`.

Closes #3.
