### PR TITLE
Additional SHACL tests and tests for the SHACL tests themselves

### DIFF
--- a/examples/trees/pg_2357.shacl.ttl
+++ b/examples/trees/pg_2357.shacl.ttl
@@ -10,20 +10,36 @@
 
 #
 # There are some sequences we can test for in pg_2357:
-#   Node_1 --(obo:has_Child)--> Node_2 --> Node_3 --> Node_4 --> Node_5 
+#   Node_1 --(obo:has_Child)--> Node_2 --> Node_3 --> Node_4 --> Node_5
 #       --> Node_6 --> Evaniscus_rufithorax
-#   
-#   Node_4 contains (Evaniscus_lansdownei, Evaniscus_marginatus, 
-#       Evaniscus_rufithorax, Evaniscus_sulcigenis, Evaniscus_tibialis)
+
+ex:CheckSequence a sh:Shape;
+    rdfs:label "Check Node_1 -> Node_2 -> Node_3 -> ... -> Evaniscus_rufithorax";
+    sh:targetNode pg_2357:Evaniscus_rufithorax;
+
+    sh:property [
+        sh:path [ sh:inversePath [ sh:oneOrMorePath obo:CDAO_0000149 ] ];
+        sh:in (
+            pg_2357:Node_6
+            pg_2357:Node_5
+            pg_2357:Node_4
+            pg_2357:Node_3
+            pg_2357:Node_2
+            pg_2357:Node_1
+        )
+    ]
+.
+
 #
-#   If A :hasSibling B, then X :hasChild A and X :hasChild B
+#   Node_4 contains (Evaniscus_lansdownei, Evaniscus_marginatus,
+#       Evaniscus_rufithorax, Evaniscus_sulcigenis, Evaniscus_tibialis)
 
 ex:CheckEvaniscusClade a sh:Shape;
-    rdfs:label "Check if Node_4 contains all five Evaniscus species."; 
+    rdfs:label "Check if Node_4 contains all five Evaniscus species.";
     sh:targetNode pg_2357:Node_4;
     sh:class obo:CDAO_0000140;
-    sh:property [ 
-        sh:path [ sh:zeroOrMorePath obo:CDAO_0000149 ];
+    sh:property [
+        sh:path [ sh:oneOrMorePath obo:CDAO_0000149 ];
         sh:in (
             pg_2357:Evaniscus_lansdownei
             pg_2357:Evaniscus_marginatus
@@ -33,7 +49,6 @@ ex:CheckEvaniscusClade a sh:Shape;
             # TODO: Should we try getting rid of these?
             # The easiest way to do this would be to distinguish leaf
             # nodes from internal nodes.
-            pg_2357:Node_4
             pg_2357:Node_5
             pg_2357:Node_6
             pg_2357:Node_7

--- a/examples/trees/pg_2357.shacl.ttl
+++ b/examples/trees/pg_2357.shacl.ttl
@@ -1,0 +1,42 @@
+@prefix ex: <http://phyloref.org/example/test_shacl.ttl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix obo: <http://purl.obolibrary.org/obo/> .
+@prefix phyloref: <http://phyloinformatics.net/phyloref.owl#> .
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix rdf: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix pg_2357: <http://phyloinformatics.net/phylo/pg_2357#> .
+
+#
+# There are some sequences we can test for in pg_2357:
+#   Node_1 --(obo:has_Child)--> Node_2 --> Node_3 --> Node_4 --> Node_5 
+#       --> Node_6 --> Evaniscus_rufithorax
+#   
+#   Node_4 contains (Evaniscus_lansdownei, Evaniscus_marginatus, 
+#       Evaniscus_rufithorax, Evaniscus_sulcigenis, Evaniscus_tibialis)
+#
+#   If A :hasSibling B, then X :hasChild A and X :hasChild B
+
+ex:CheckEvaniscusClade a sh:Shape;
+    rdfs:label "Check if Node_4 contains all five Evaniscus species."; 
+    sh:targetNode pg_2357:Node_4;
+    sh:class obo:CDAO_0000140;
+    sh:property [ 
+        sh:path [ sh:zeroOrMorePath obo:CDAO_0000149 ];
+        sh:in (
+            pg_2357:Evaniscus_lansdownei
+            pg_2357:Evaniscus_marginatus
+            pg_2357:Evaniscus_rufithorax
+            pg_2357:Evaniscus_sulcigenis
+            pg_2357:Evaniscus_tibialis
+            # TODO: Should we try getting rid of these?
+            # The easiest way to do this would be to distinguish leaf
+            # nodes from internal nodes.
+            pg_2357:Node_4
+            pg_2357:Node_5
+            pg_2357:Node_6
+            pg_2357:Node_7
+        );
+    ];
+.

--- a/tests/ValidationShapes.ttl
+++ b/tests/ValidationShapes.ttl
@@ -19,6 +19,7 @@ ex:Node a sh:Shape;
     sh:or (
         [
             # 1. A CDAO:hasChild relationship with another node.
+            sh:message "Every node must have a hasChild relationship with another node.";
             sh:property [
                 sh:predicate obo:CDAO_0000149;
                 sh:class obo:CDAO_0000140;
@@ -27,6 +28,7 @@ ex:Node a sh:Shape;
         ]
         [
             # 2. A phyloref:has_Sibling relationship with another node.
+            sh:message "Every node must have a has_Sibling relationship with another node.";
             sh:property [
                 sh:predicate phyloref:has_Sibling;
                 sh:class obo:CDAO_0000140;
@@ -34,4 +36,11 @@ ex:Node a sh:Shape;
             ];
         ]
     );
+
+    # No node should be a child of itself.
+    sh:sparql [
+        a sh:SPARQLConstraint;
+        sh:message "No node should be a child of itself.";
+        sh:select "SELECT * WHERE { $this <http://purl.obolibrary.org/obo/CDAO_0000149> $this }";
+    ];
 .

--- a/tests/libshacl.py
+++ b/tests/libshacl.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+
+"""libshacl.py: Library of functions for communicating with the SHACL Java executable."""
+
+import os
+import rdflib
+import subprocess
+import xml.sax
+
+def exec_testShacl(cmdline=[], stdin=""):
+    """Send those command line arguments to testShacl.class.
+    Returns: (exitcode, output, error)
+    """
+
+    # We need to add JENAHOME to the classpath so testShacl can find
+    # the JENA library.
+    environment = os.environ
+
+    starts_with = ["java", "-jar", "target/testShacl-0.1-SNAPSHOT.jar"]
+
+    # Based on http://stackoverflow.com/a/1996540/27310
+    print starts_with
+    print cmdline
+    p = subprocess.Popen(starts_with + cmdline, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=environment, cwd="tests/java")
+    stdout, stderr = p.communicate(stdin)
+    print stdout
+    print stderr
+    return (p.returncode, stdout, stderr)
+
+def validateShacl(shapePath, owlPath, expect_valid=True):
+    """Validate a shape against an OWL ontology representation of a tree.
+        - expect_valid: if True, that means we're expecting a success; if 
+            False, that means that the OWL file is incorrect and we're 
+            expecting a failure.
+    """
+    (rc, stdout, stderr) = exec_testShacl([shapePath, owlPath])
+    assert rc == (0 if expect_valid else 1)
+
+    # stdout should always be a Turtle document.
+    graph = rdflib.Graph()
+    try:
+        graph.parse(format='turtle', data=stdout)
+    except xml.sax.SAXParseException as e:
+        print "SAXParseException parsing '{0}': {1}".format(tree, e)
+        assert False
+
+    # There should be no triples.
+    if expect_valid:
+        assert len(graph) == 0
+    else:
+        assert len(graph) > 0

--- a/tests/test_shacl.py
+++ b/tests/test_shacl.py
@@ -6,41 +6,7 @@ import os
 import rdflib
 import subprocess
 import xml.sax
-
-def exec_testShacl(cmdline=[], stdin=""):
-    """Send those command line arguments to testShacl.class.
-    Returns: (exitcode, output, error)
-    """
-
-    # We need to add JENAHOME to the classpath so testShacl can find
-    # the JENA library.
-    environment = os.environ
-
-    starts_with = ["java", "-jar", "target/testShacl-0.1-SNAPSHOT.jar"]
-
-    # Based on http://stackoverflow.com/a/1996540/27310
-    print starts_with
-    print cmdline
-    p = subprocess.Popen(starts_with + cmdline, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=environment, cwd="tests/java")
-    stdout, stderr = p.communicate(stdin)
-    print stdout
-    print stderr
-    return (p.returncode, stdout, stderr)
-
-def validateShacl(shapePath, owlPath):
-    (rc, stdout, stderr) = exec_testShacl([shapePath, owlPath])
-    assert rc == 0
-
-    # stdout should always be a Turtle document.
-    graph = rdflib.Graph()
-    try:
-        graph.parse(format='turtle', data=stdout)
-    except xml.sax.SAXParseException as e:
-        print "SAXParseException parsing '{0}': {1}".format(tree, e)
-        assert False
-
-    # There should be no triples.
-    assert len(graph) == 0
+from libshacl import exec_testShacl, validateShacl
 
 def test_execute():
     """Make sure we can execute testShacl."""

--- a/tests/test_shacl.py
+++ b/tests/test_shacl.py
@@ -41,7 +41,6 @@ def validateShacl(shapePath, owlPath):
 
     # There should be no triples.
     assert len(graph) == 0
- 
 
 def test_execute():
     """Make sure we can execute testShacl."""
@@ -52,7 +51,7 @@ def test_execute():
     assert stderr.startswith("testShacl ")
 
     # Test all the example trees against ValidationShapes.
-    validateShacl("../ValidationShapes.ttl", "../../examples/trees/pg_2357.owl")  
+    validateShacl("../ValidationShapes.ttl", "../../examples/trees/pg_2357.owl")
 
     # Test each tree against its customized validation.
     validateShacl("../../examples/trees/pg_2357.shacl.ttl", "../../examples/trees/pg_2357.owl")

--- a/tests/test_shacl.py
+++ b/tests/test_shacl.py
@@ -27,16 +27,8 @@ def exec_testShacl(cmdline=[], stdin=""):
     print stderr
     return (p.returncode, stdout, stderr)
 
-def test_execute():
-    """Make sure we can execute testShacl."""
-
-    # Can we execute testShacl at all?
-    (rc, stdout, stderr) = exec_testShacl(["--version"])
-    assert rc == 0
-    assert stderr.startswith("testShacl ")
-
-    # Test all the example trees against ValidationShapes.
-    (rc, stdout, stderr) = exec_testShacl(["../ValidationShapes.ttl", "../../examples/trees/pg_2357.owl"])
+def validateShacl(shapePath, owlPath):
+    (rc, stdout, stderr) = exec_testShacl([shapePath, owlPath])
     assert rc == 0
 
     # stdout should always be a Turtle document.
@@ -49,5 +41,19 @@ def test_execute():
 
     # There should be no triples.
     assert len(graph) == 0
-        
+ 
+
+def test_execute():
+    """Make sure we can execute testShacl."""
+
+    # Can we execute testShacl at all?
+    (rc, stdout, stderr) = exec_testShacl(["--version"])
+    assert rc == 0
+    assert stderr.startswith("testShacl ")
+
+    # Test all the example trees against ValidationShapes.
+    validateShacl("../ValidationShapes.ttl", "../../examples/trees/pg_2357.owl")  
+
+    # Test each tree against its customized validation.
+    validateShacl("../../examples/trees/pg_2357.shacl.ttl", "../../examples/trees/pg_2357.owl")
 

--- a/tests/test_shacl_shapes.py
+++ b/tests/test_shacl_shapes.py
@@ -51,6 +51,10 @@ def test_shacl_shapes():
     g.add((node3, phyloref_has_Sibling, node2))
     save_graph_and_validate(g, True)
 
+    # No node should be the child of itself.
+    g.add((node2, CDAO_hasChild, node2))
+    save_graph_and_validate(g, False)
+
 def save_graph_and_validate(graph, expect_valid):
     """Write a graph to a temporary file, and then validate it."""
 

--- a/tests/test_shacl_shapes.py
+++ b/tests/test_shacl_shapes.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python
+
+"""test_shacl_shapes.py: Test SHACL shapes by querying them against failing trees."""
+
+import os
+from rdflib import BNode, URIRef
+from rdflib.graph import Graph
+from rdflib.namespace import RDF, RDFS
+import tempfile
+import libshacl
+
+# Some URIRefs we'll need.
+CDAO_Node = URIRef('http://purl.obolibrary.org/obo/CDAO_0000140') 
+CDAO_hasChild = URIRef('http://purl.obolibrary.org/obo/CDAO_0000149')
+phyloref_has_Sibling = URIRef('http://phyloinformatics.net/phyloref.owl#has_Sibling')
+
+def test_shacl_shapes():
+    """Test SHACL shapes that should fail SHACL validation."""
+
+    # We start by constructing a tree that consists of a single node.
+    g = Graph()
+    node1 = BNode()
+    g.add((node1, RDF.type, CDAO_Node))
+    save_graph_and_validate(g, False)
+
+    # If we add a non-CDAO_Node as a child, we should fail.
+    non_node = BNode()
+    g.add((node1, CDAO_hasChild, non_node))
+    save_graph_and_validate(g, False)
+    g.remove((node1, CDAO_hasChild, non_node))
+
+    # If we add another node with another CDAO_Node, we should fail.
+    node2 = BNode()
+    g.add((node2, RDF.type, CDAO_Node))
+    g.add((node1, RDFS.subClassOf, node2))
+    save_graph_and_validate(g, False)
+    g.remove((node1, RDFS.subClassOf, node2))
+
+    # But if we add another node as a CDAO_hasChild, we should succeed.
+    # TODO: This currently fails, since node2 does not have a CDAO_hasChild
+    # to another node.
+    g.add((node1, CDAO_hasChild, node2))
+    save_graph_and_validate(g, False)
+    g.add((node2, CDAO_hasChild, node1))
+    save_graph_and_validate(g, True)
+
+    # If we add a third node as a sibling, that should be fine too.
+    # TODO: We should check to see if siblings mark each other.
+    node3 = BNode()
+    g.add((node3, RDF.type, CDAO_Node))
+    g.add((node3, phyloref_has_Sibling, node2))
+    save_graph_and_validate(g, True)
+
+def save_graph_and_validate(graph, expect_valid):
+    """Write a graph to a temporary file, and then validate it."""
+
+    # Create a temporary file.
+    with tempfile.NamedTemporaryFile() as f:
+        # Save graph to file.
+        graph.serialize(f.name, format="xml")
+
+        # Test graph against ValidationShapes.
+        libshacl.validateShacl("../ValidationShapes.ttl", f.name, expect_valid=expect_valid)
+    
+        # TODO: This should clear the stdout gathered by pytest
+        # upto this point so we only show the results of the
+        # latest test, but it's not clear how to do that.
+


### PR DESCRIPTION
In this pull request, I add the SHACL-based tests I suggested in http://www.phyloref.org/blog/2016/10/validating-shapes/, namely:
 - Tree-specific sequences and whether certain tails are found within a particular "node".
 - A SPARQL-based test to check whether a node is listed as its own child.

I also add a test script that deliberately constructs invalid trees to ensure that the SHACL tests catch them. This lead to me rearranging the SHACL code somewhat.